### PR TITLE
chore: add .env.example for Bitget API (placeholder)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Copy this file to .env and fill in real values. Do NOT commit secrets.
+BITGET_API_KEY=REPLACE_ME
+
+# Optional Bitget fields (uncomment and fill if needed)
+# BITGET_API_SECRET=REPLACE_ME
+# BITGET_PASSPHRASE=REPLACE_ME


### PR DESCRIPTION
Fix #4